### PR TITLE
Add missing routes and tests

### DIFF
--- a/src/router/api/indexApi.js
+++ b/src/router/api/indexApi.js
@@ -11,6 +11,7 @@ const profesoresRoutes = require('./profesores.routes.js');
 const usuariosRoutes = require('./usuarios.routes.js');
 const administradoresRoutes = require('./administradores.routes.js');
 const aulasRoutes = require('./aulas.routes.js');
+const inscripcionesRoutes = require('./inscripciones.routes.js');
 
 // Importar y usar las rutas
 router.use('/alumnos', alumnosRoutes);
@@ -22,5 +23,6 @@ router.use('/profesores', profesoresRoutes);
 router.use('/usuarios', usuariosRoutes);
 router.use('/administradores', administradoresRoutes);
 router.use('/aulas', aulasRoutes);
+router.use('/inscripciones', inscripcionesRoutes);
 
 module.exports = router;

--- a/src/router/api/inscripciones.routes.js
+++ b/src/router/api/inscripciones.routes.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const router = express.Router();
+const { Inscripcion } = require('../../database/models');
+
+// Obtener todas las inscripciones
+router.get('/', async (req, res) => {
+    try {
+        const inscripciones = await Inscripcion.findAll();
+        res.json(inscripciones);
+    } catch (error) {
+        res.status(500).json({ error: 'Error al obtener las inscripciones' });
+    }
+});
+
+// Obtener una inscripcion por ID
+router.get('/:id', async (req, res) => {
+    try {
+        const inscripcion = await Inscripcion.findByPk(req.params.id);
+        if (!inscripcion) {
+            return res.status(404).json({ error: 'Inscripción no encontrada' });
+        }
+        res.json(inscripcion);
+    } catch (error) {
+        res.status(500).json({ error: 'Error al obtener la inscripción' });
+    }
+});
+
+// Crear una nueva inscripcion
+router.post('/', async (req, res) => {
+    try {
+        const nuevaInscripcion = await Inscripcion.create(req.body);
+        res.status(201).json(nuevaInscripcion);
+    } catch (error) {
+        res.status(500).json({ error: 'Error al crear la inscripción' });
+    }
+});
+
+// Actualizar una inscripcion
+router.put('/:id', async (req, res) => {
+    try {
+        const [updated] = await Inscripcion.update(req.body, {
+            where: { id: req.params.id }
+        });
+        if (!updated) {
+            return res.status(404).json({ error: 'Inscripción no encontrada' });
+        }
+        const inscripcionActualizada = await Inscripcion.findByPk(req.params.id);
+        res.json(inscripcionActualizada);
+    } catch (error) {
+        res.status(500).json({ error: 'Error al actualizar la inscripción' });
+    }
+});
+
+// Eliminar una inscripcion
+router.delete('/:id', async (req, res) => {
+    try {
+        const deleted = await Inscripcion.destroy({
+            where: { id: req.params.id }
+        });
+        if (!deleted) {
+            return res.status(404).json({ error: 'Inscripción no encontrada' });
+        }
+        res.status(204).end();
+    } catch (error) {
+        res.status(500).json({ error: 'Error al eliminar la inscripción' });
+    }
+});
+
+module.exports = router;

--- a/tests/carreras.test.js
+++ b/tests/carreras.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('Rutas de carreras', () => {
+    it('debería responder a GET', async () => {
+        const res = await request(app).get('/api/carreras');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('GET carreras');
+    });
+
+    it('debería responder a POST', async () => {
+        const res = await request(app).post('/api/carreras');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('POST carreras');
+    });
+
+    it('debería responder a PUT', async () => {
+        const res = await request(app).put('/api/carreras/1');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('PUT carreras con ID: 1');
+    });
+
+    it('debería responder a DELETE', async () => {
+        const res = await request(app).delete('/api/carreras/1');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('DELETE carreras con ID: 1');
+    });
+});

--- a/tests/inscripciones.test.js
+++ b/tests/inscripciones.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('Rutas de inscripciones', () => {
+    let inscripcionId = null;
+    const alumnoId = '11111111-1111-1111-1111-111111111111';
+    const cursoId = '22222222-2222-2222-2222-222222222222';
+
+    it('debería crear una nueva inscripción', async () => {
+        const res = await request(app).post('/api/inscripciones').send({
+            alumno_id: alumnoId,
+            curso_id: cursoId,
+            fecha_inscripcion: '2024-01-01'
+        });
+        expect(res.statusCode).toBe(201);
+        expect(res.body).toHaveProperty('id');
+        inscripcionId = res.body.id;
+    });
+
+    it('debería obtener todas las inscripciones', async () => {
+        const res = await request(app).get('/api/inscripciones');
+        expect(res.statusCode).toBe(200);
+        expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it('debería obtener una inscripción por ID', async () => {
+        const res = await request(app).get(`/api/inscripciones/${inscripcionId}`);
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toHaveProperty('id', inscripcionId);
+    });
+
+    it('debería actualizar una inscripción', async () => {
+        const res = await request(app).put(`/api/inscripciones/${inscripcionId}`).send({
+            alumno_id: alumnoId,
+            curso_id: cursoId,
+            fecha_inscripcion: '2024-02-01'
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toHaveProperty('fecha_inscripcion');
+    });
+
+    it('debería eliminar una inscripción', async () => {
+        const res = await request(app).delete(`/api/inscripciones/${inscripcionId}`);
+        expect(res.statusCode).toBe(204);
+    });
+});

--- a/tests/notas.test.js
+++ b/tests/notas.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('Rutas de notas', () => {
+    it('debería responder a GET', async () => {
+        const res = await request(app).get('/api/notas');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('GET notas');
+    });
+
+    it('debería responder a POST', async () => {
+        const res = await request(app).post('/api/notas');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('POST notas');
+    });
+
+    it('debería responder a PUT', async () => {
+        const res = await request(app).put('/api/notas/1');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('PUT nota con ID: 1');
+    });
+
+    it('debería responder a DELETE', async () => {
+        const res = await request(app).delete('/api/notas/1');
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe('DELETE nota con ID: 1');
+    });
+});


### PR DESCRIPTION
## Summary
- implement inscripciones CRUD routes
- register inscripciones routes in `indexApi`
- add missing tests for carreras and notas
- add full test suite for inscripciones

## Testing
- `npm test` *(fails: jest missing)*

------
https://chatgpt.com/codex/tasks/task_e_68538a9f5c94832b9c1a50b1203abf0a