### PR TITLE
Corregir contenido de Tailwind para incluir src y restaurar estilos UI

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   darkMode: ["class"],
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
### Motivation
- Tailwind no estaba detectando las clases usadas en la app porque `tailwind.config.ts` no incluía el árbol `src` ni las extensiones modernas (`js/ts/jsx/tsx/mdx`) en la opción `content`, lo que provocaba que los estilos de la UI no se generaran.

### Description
- Actualicé `tailwind.config.ts` para que `content` incluya `./src/**/*.{js,ts,jsx,tsx,mdx}` y también escanee `./app`, `./components` y `./lib` con las mismas extensiones.

### Testing
- Ejecuté `npm run build` exitosamente, lancé el servidor con `npm run dev` y capturé la página `/login` vía Playwright para verificar visualmente los estilos, y ejecuté `rg` para buscar referencias a shaders (no se encontraron resultados).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1142700ec832ba2e91cc764e7dd0a)