### PR TITLE
Use CSS color variables for light/dark themes and wire them into Tailwind; expand content globs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,10 +4,22 @@
 
 :root {
   color-scheme: light;
+  --background: 248 250 252;
+  --foreground: 15 23 42;
+  --border: 226 232 240;
+  --primary: 22 163 74;
+  --primary-hover: 21 128 61;
+  --accent: 220 252 231;
 }
 
 .dark {
   color-scheme: dark;
+  --background: 2 6 23;
+  --foreground: 226 232 240;
+  --border: 51 65 85;
+  --primary: 34 197 94;
+  --primary-hover: 22 163 74;
+  --accent: 30 41 59;
 }
 
 body {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,16 +2,21 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   darkMode: ["class"],
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
   theme: {
     extend: {
       colors: {
-        border: "#E2E8F0",
-        background: "#F8FAFC",
-        foreground: "#0F172A",
-        primary: "#16A34A",
-        "primary-hover": "#15803D",
-        accent: "#DCFCE7"
+        border: "hsl(var(--border))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: "hsl(var(--primary))",
+        "primary-hover": "hsl(var(--primary-hover))",
+        accent: "hsl(var(--accent))"
       }
     }
   },


### PR DESCRIPTION
### Motivation

- Centralize theme tokens as CSS variables to make light/dark theming simpler and to enable runtime color adjustments.
- Ensure Tailwind processes all source files including files under `src` and `.mdx`/JS(X)/TS(X) extensions so generated utilities include all usages.

### Description

- Added CSS custom properties for color tokens in `:root` and `.dark` in `src/app/globals.css` and applied `bg-background` and `text-foreground` to `body`.
- Replaced hard-coded hex colors in `tailwind.config.ts` with `hsl(var(--...))` references so Tailwind colors are driven by the CSS variables.
- Expanded the `content` globs in `tailwind.config.ts` to include `./src/**/*.{js,ts,jsx,tsx,mdx}` and added JS/JSX/MDX extensions for all existing folders.
- Kept `darkMode: ["class"]` so dark theme variables activate via the `.dark` class.

### Testing

- Ran a TypeScript type-check (`tsc --noEmit`) which completed successfully.
- Performed a project build (`npm run build`) to regenerate Tailwind CSS and the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1142700ec832ba2e91cc764e7dd0a)